### PR TITLE
Firebase-create-Workboard-path

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,19 +1,21 @@
 {
-  "hosting": {
-    "public": "out",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ]
-  },
-  "emulators": {
     "hosting": {
-      "port": 5033
+        "public": "out",
+        "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+        "rewrites": [
+            {
+                "source": "/workboard",
+                "destination": "/workboard.html"
+            }
+        ]
     },
-    "ui": {
-      "enabled": true
-    },
-    "singleProjectMode": true
-  }
+    "emulators": {
+        "hosting": {
+            "port": 5033
+        },
+        "ui": {
+            "enabled": true
+        },
+        "singleProjectMode": true
+    }
 }


### PR DESCRIPTION
Path `/workboard` should land on the workboard page, this also fixes the reload issue that used to return 404 