### PR TITLE
Refactor workboard

### DIFF
--- a/src/components/Home/components/TopNav/DropdownMenu.tsx
+++ b/src/components/Home/components/TopNav/DropdownMenu.tsx
@@ -2,28 +2,17 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '../../types';
+import useOutsideClick from '@/hooks/useOutsideClick';
 
 interface Props {
     buttonsList: Button[];
 }
 
 const DropdownMenu: React.FC<Props> = ({ buttonsList }) => {
-    const [isOpen, setOpen] = useState(false);
-    const nodeRef = useRef<HTMLDivElement>(null);
+    const [isOpen, setIsOpen] = useState(false);
+    const ref = useOutsideClick(() => setIsOpen(false));
 
-    // TODO: Revisit this type
-    const handleClickOutside = (event: any) => {
-        if (nodeRef.current && !nodeRef.current.contains(event.target)) {
-            return setOpen(false);
-        }
-    };
-
-    useEffect(() => {
-        document.addEventListener('click', handleClickOutside, true);
-        return () => document.removeEventListener('click', handleClickOutside, true);
-    });
-
-    const dropdown = (
+    const DropdownList = (
         <ul className="absolute -right-3 bg-grey-120 p-3 space-y-2 rounded-b-md shadow-lg">
             {buttonsList.map((button) => (
                 <li key={button.id}>
@@ -31,7 +20,7 @@ const DropdownMenu: React.FC<Props> = ({ buttonsList }) => {
                         className="text-white"
                         onClick={() => {
                             button.onClick();
-                            setOpen(false);
+                            setIsOpen(false);
                         }}
                     >
                         {button.name}
@@ -42,16 +31,16 @@ const DropdownMenu: React.FC<Props> = ({ buttonsList }) => {
     );
 
     return (
-        <div ref={nodeRef}>
+        <div ref={ref}>
             <button
                 aria-label="Dropdown menu"
                 onClick={() => {
-                    setOpen(!isOpen);
+                    setIsOpen(!isOpen);
                 }}
             >
                 <FontAwesomeIcon icon={faBars} className="text-white" />
             </button>
-            <div className="relative">{isOpen && dropdown}</div>
+            <div className="relative">{isOpen && DropdownList}</div>
         </div>
     );
 };

--- a/src/components/Workboard/components/Card.tsx
+++ b/src/components/Workboard/components/Card.tsx
@@ -1,53 +1,31 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { CardData, ItemToDelete } from '../types';
 
 interface Props {
     card: CardData;
     onEditCard: (cardId: string, cardText: string) => void;
     onDeleteCard: (item: ItemToDelete) => void;
-    setItemToDelete: (item: ItemToDelete) => void;
 }
 
-const Card: React.FC<Props> = ({ card, onEditCard, onDeleteCard, setItemToDelete }) => {
-    const [isFocused, setIsFocused] = useState(false);
+const Card: React.FC<Props> = ({ card, onEditCard, onDeleteCard }) => {
     const [text, setText] = useState(card.text);
-    const ref = useRef<HTMLDivElement>(null);
 
     const handleChange = (ev: React.ChangeEvent<HTMLDivElement>) => {
         setText(ev.target.innerHTML);
     };
 
     const handleClickOutside = () => {
-        // Apply changes only to the focused card
-        if (!isFocused) return;
-
         if (text.length === 0) {
             onDeleteCard({ id: card.id, kind: 'card' });
         } else {
             onEditCard(card.id, text);
         }
-        setIsFocused(false);
     };
-
-    useEffect(() => {
-        const onOutsideClick = (event: any) => {
-            if (ref.current && !ref.current.contains(event.target)) {
-                handleClickOutside();
-            }
-        };
-
-        document.addEventListener('click', onOutsideClick, true);
-
-        return () => {
-            document.removeEventListener('click', onOutsideClick, true);
-        };
-    });
 
     return (
         <div
-            ref={ref}
             className="group flex gap-x-1 max-h-44 bg-white rounded-md shadow-md"
-            onFocus={() => setIsFocused(true)}
+            onBlur={handleClickOutside}
         >
             <div
                 className="w-full p-2"

--- a/src/components/Workboard/components/Column.tsx
+++ b/src/components/Workboard/components/Column.tsx
@@ -1,6 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import React, { useState } from 'react';
 import { ColumnData, ItemToDelete } from '../types';
 import Card from './Card';
 import Dropdown from './Dropdown';
@@ -26,7 +24,6 @@ const Column: React.FC<Props> = ({
     const [colTitle, setColTitle] = useState(column.title);
     const [showCreateCard, setShowCreateCard] = useState(false);
     const [showEditCol, setShowEditCol] = useState(false);
-    const colTitleRef = useRef<HTMLDivElement>(null);
 
     const colExtraButtons = [
         {
@@ -41,44 +38,23 @@ const Column: React.FC<Props> = ({
 
     const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => setColTitle(ev.target.value);
 
-    const cancelEditColumn = () => {
-        setColTitle(column.title);
+    const handleClickOutside = () => {
+        onEditColumn(column.id, colTitle);
         setShowEditCol(false);
     };
-
-    useEffect(() => {
-        const handleClickOutside = (event: any) => {
-            if (colTitleRef.current && !colTitleRef.current.contains(event.target)) {
-                return cancelEditColumn();
-            }
-        };
-        document.addEventListener('click', handleClickOutside, true);
-        return () => document.removeEventListener('click', handleClickOutside, true);
-    });
 
     return (
         <div className="bg-grey-90 w-[18.75rem] rounded-lg">
             <div className="flex justify-between p-2 bg-grey-90 brightness-95 rounded-t-lg">
                 {showEditCol ? (
-                    <div ref={colTitleRef} className="flex gap-x-2">
-                        <input
-                            autoFocus
-                            className="bg-white w-[15rem]"
-                            type="text"
-                            value={colTitle}
-                            onChange={handleChange}
-                        />
-                        <button
-                            className="w-8 h-8 text-grey-100 rounded-full
-                                hover:text-blue-100b hover:bg-grey-100 hover:bg-opacity-20"
-                            onClick={() => {
-                                onEditColumn(column.id, colTitle);
-                                setShowEditCol(false);
-                            }}
-                        >
-                            <FontAwesomeIcon icon={faCheck} />
-                        </button>
-                    </div>
+                    <input
+                        autoFocus
+                        className="bg-white w-full p-1"
+                        type="text"
+                        value={colTitle}
+                        onBlur={handleClickOutside}
+                        onChange={handleChange}
+                    />
                 ) : (
                     <>
                         <span className="font-bold my-auto">{column.title}</span>
@@ -93,7 +69,6 @@ const Column: React.FC<Props> = ({
                         card={card}
                         onEditCard={onEditCard}
                         onDeleteCard={onDeleteCard}
-                        setItemToDelete={setItemToDelete}
                     />
                 ))}
 

--- a/src/components/Workboard/components/Dropdown.tsx
+++ b/src/components/Workboard/components/Dropdown.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import useOutsideClick from '@/hooks/useOutsideClick';
 
 type Button = {
     label: string;
@@ -12,21 +13,7 @@ interface Props {
 
 const Dropdown: React.FC<Props> = ({ buttonsList }) => {
     const [isOpen, setIsOpen] = useState(false);
-    const ref = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        const handleClickOutside = (event: any) => {
-            if (ref.current && !ref.current.contains(event.target)) {
-                setIsOpen(false);
-            }
-        };
-
-        if (isOpen) {
-            document.addEventListener('click', handleClickOutside, true);
-        }
-
-        return () => document.removeEventListener('click', handleClickOutside, true);
-    });
+    const ref = useOutsideClick(() => setIsOpen(false));
 
     const DropdownList = (
         <ul className="absolute right-0 w-max bg-white rounded-b-md rounded-tl-md shadow-md">
@@ -39,6 +26,7 @@ const Dropdown: React.FC<Props> = ({ buttonsList }) => {
             ))}
         </ul>
     );
+
     return (
         <div ref={ref}>
             <button

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+
+const useOutsideClick = (callback: () => void) => {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const onOutsideClick = (event: any) => {
+            if (ref.current && !ref.current.contains(event.target)) {
+                callback();
+            }
+        };
+
+        document.addEventListener('click', onOutsideClick, true);
+
+        return () => {
+            document.removeEventListener('click', onOutsideClick, true);
+        };
+    }, [ref]);
+
+    return ref;
+};
+
+export default useOutsideClick;


### PR DESCRIPTION
To check if user clicked outside on input, onBlur attribute will be used. Column and cards use different logic since we don't want to delete a column if there's no text, but that's ok for a card.

Dropdowns are being re-used, although slightly different, the logic if it has been clicked outside is still the same, therefore I created a custom hook `useOutsideClick`