### PR TITLE
Save drag and drop position

### DIFF
--- a/src/components/Workboard/components/Card.tsx
+++ b/src/components/Workboard/components/Card.tsx
@@ -5,10 +5,12 @@ interface Props {
     card: CardData;
     onEditCard: (cardId: string, cardText: string) => void;
     onDeleteCard: (item: ItemToDelete) => void;
+    onDrop: (card: CardData) => void;
 }
 
-const Card: React.FC<Props> = ({ card, onEditCard, onDeleteCard }) => {
+const Card: React.FC<Props> = ({ card, onEditCard, onDeleteCard, onDrop }) => {
     const [text, setText] = useState(card.text);
+    const [isDragging, setIsDragging] = useState(false);
 
     const handleChange = (ev: React.ChangeEvent<HTMLDivElement>) => {
         setText(ev.target.innerHTML);
@@ -25,8 +27,15 @@ const Card: React.FC<Props> = ({ card, onEditCard, onDeleteCard }) => {
     return (
         <div
             id={card.id}
-            className="draggable group flex gap-x-1 max-h-44 bg-white rounded-md shadow-md"
+            className={`draggable group flex gap-x-1 max-h-44 bg-white rounded-md shadow-md ${
+                isDragging && 'opacity-20 dragging'
+            }`}
             draggable
+            onDragStart={() => setIsDragging(true)}
+            onDragEnd={() => {
+                setIsDragging(false);
+                onDrop(card);
+            }}
             onBlur={handleClickOutside}
         >
             <div

--- a/src/components/Workboard/types.ts
+++ b/src/components/Workboard/types.ts
@@ -14,3 +14,8 @@ export type ItemToDelete = {
     kind: 'card' | 'column';
     text?: string;
 };
+
+export type DropColumn = {
+    newColId?: string;
+    nextCardId?: string;
+};


### PR DESCRIPTION
Card has the `onDragStart` attribute that sets the dragging state which will be used to pass it the `dragging` class
Card also has the `onDragEnd` attribute which will handle the drop by placing the card in the appropriate column.

Column handles the `onDragOver` which passes the new column's id as well as the closest element's id above which we are hovering.

Finally, index takes care of saving the new card in existing columns (state and localstorage) with the id's of the new column, next card id (if any) and card data.

A new card gets placed either at the end of a column, or before another one.
 